### PR TITLE
Remove reference to license

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,6 @@ setup(
     version=info['__version__'],
     packages=find_packages(exclude=()),
     url=info['__url__'],
-    license=['__license__'],
     author=info['__author__'],
     author_email=info['__email__'],
     description=info['__description__'],


### PR DESCRIPTION
`setuptools` in Python 3.10 has difficulty reading the license field in this packages `setup.py`, which causes `pip install` to fail. Removing the license field causes the pip install to succeed. 


Please see output below:

```
root@ae73c9e310d1:/code# pip install --user --use-deprecated=legacy-resolver -r requirements.txt

Collecting git+https://github.com/filintod/pyremotelogin.git (from -r requirements.txt (line 6))
  Cloning https://github.com/filintod/pyremotelogin.git to /tmp/pip-req-build-i9u96tmr
  Running command git clone --filter=blob:none --quiet https://github.com/filintod/pyremotelogin.git /tmp/pip-req-build-i9u96tmr
  Resolved https://github.com/filintod/pyremotelogin.git to commit e2a4df7fd69d21eccdf1aec55c33a839de9157f1
  Preparing metadata (setup.py) ... error
  error: subprocess-exited-with-error

  × python setup.py egg_info did not run successfully.
  │ exit code: 1
  ╰─> [31 lines of output]
      running egg_info
      creating /tmp/pip-pip-egg-info-z7xp_wbe/remotelogin.egg-info
      writing /tmp/pip-pip-egg-info-z7xp_wbe/remotelogin.egg-info/PKG-INFO
      Traceback (most recent call last):
        File "<string>", line 2, in <module>
        File "<pip-setuptools-caller>", line 34, in <module>
        File "/tmp/pip-req-build-i9u96tmr/setup.py", line 31, in <module>
          setup(
        File "/usr/local/lib/python3.10/dist-packages/setuptools/__init__.py", line 87, in setup
          return distutils.core.setup(**attrs)
        File "/usr/local/lib/python3.10/dist-packages/setuptools/_distutils/core.py", line 148, in setup
          return run_commands(dist)
        File "/usr/local/lib/python3.10/dist-packages/setuptools/_distutils/core.py", line 163, in run_commands
          dist.run_commands()
        File "/usr/local/lib/python3.10/dist-packages/setuptools/_distutils/dist.py", line 967, in run_commands
          self.run_command(cmd)
        File "/usr/local/lib/python3.10/dist-packages/setuptools/dist.py", line 1214, in run_command
          super().run_command(command)
        File "/usr/local/lib/python3.10/dist-packages/setuptools/_distutils/dist.py", line 986, in run_command
          cmd_obj.run()
        File "/usr/local/lib/python3.10/dist-packages/setuptools/command/egg_info.py", line 301, in run
          writer(self, ep.name, os.path.join(self.egg_info, ep.name))
        File "/usr/local/lib/python3.10/dist-packages/setuptools/command/egg_info.py", line 665, in write_pkg_info
          metadata.write_pkg_info(cmd.egg_info)
        File "/usr/local/lib/python3.10/dist-packages/setuptools/_distutils/dist.py", line 1118, in write_pkg_info
          self.write_pkg_file(pkg_info)
        File "/usr/local/lib/python3.10/dist-packages/setuptools/dist.py", line 193, in write_pkg_file
          license = rfc822_escape(self.get_license())
        File "/usr/local/lib/python3.10/dist-packages/setuptools/_distutils/util.py", line 494, in rfc822_escape
          lines = header.split('\n')
      AttributeError: 'list' object has no attribute 'split'
      [end of output]

  note: This error originates from a subprocess, and is likely not a problem with pip.
error: metadata-generation-failed

× Encountered error while generating package metadata.
╰─> from git+https://github.com/filintod/pyremotelogin.git

note: This is an issue with the package mentioned above, not pip.
hint: See above for details.
WARNING: You are using pip version 22.0.4; however, version 22.1.2 is available.
You should consider upgrading via the '/usr/bin/python -m pip install --upgrade pip' command.
```